### PR TITLE
implement NewChoice convenience constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ func main() {
     rand.Seed(time.Now().UTC().UnixNano()) // always seed random!
 
     c := wr.NewChooser(
-        wr.Choice{Item: "🍆", Weight: 0},
+        wr.Choice{Item: "🍆", Weight: 0}, // alternatively: wr.NewChoice('🍆', 0)
         wr.Choice{Item: "🍋", Weight: 1},
         wr.Choice{Item: "🍊", Weight: 1},
         wr.Choice{Item: "🍉", Weight: 3},

--- a/examples/main.go
+++ b/examples/main.go
@@ -12,7 +12,7 @@ func main() {
 	rand.Seed(time.Now().UTC().UnixNano()) // always seed random!
 
 	c := wr.NewChooser(
-		wr.Choice{Item: '🍆', Weight: 0},
+		wr.Choice{Item: '🍆', Weight: 0}, // alternatively: wr.NewChoice('🍆', 0)
 		wr.Choice{Item: '🍋', Weight: 1},
 		wr.Choice{Item: '🍊', Weight: 1},
 		wr.Choice{Item: '🍉', Weight: 3},

--- a/weightedrand.go
+++ b/weightedrand.go
@@ -15,10 +15,15 @@ import (
 	"sort"
 )
 
-// Choice is a generic wrapper that can be used to add weights for any object
+// Choice is a generic wrapper that can be used to add weights for any item.
 type Choice struct {
 	Item   interface{}
 	Weight uint
+}
+
+// NewChoice creates a new Choice with specified item and weight.
+func NewChoice(item interface{}, weight uint) Choice {
+	return Choice{Item: item, Weight: weight}
 }
 
 // A Chooser caches many possible Choices in a structure designed to improve
@@ -29,7 +34,7 @@ type Chooser struct {
 	max    int
 }
 
-// NewChooser initializes a new Chooser consisting of the possible Choices.
+// NewChooser initializes a new Chooser for picking from the provided Choices.
 func NewChooser(cs ...Choice) Chooser {
 	sort.Slice(cs, func(i, j int) bool {
 		return cs[i].Weight < cs[j].Weight

--- a/weightedrand_test.go
+++ b/weightedrand_test.go
@@ -16,7 +16,7 @@ func mockChoices(n int) []Choice {
 	for i := 0; i < n; i++ {
 		s := "⚽️"
 		w := rand.Intn(10)
-		c := Choice{Item: s, Weight: uint(w)}
+		c := NewChoice(s, uint(w))
 		choices = append(choices, c)
 	}
 	return choices
@@ -35,7 +35,7 @@ func TestWeightedChoice(t *testing.T) {
 	presorted data. */
 	list := rand.Perm(10)
 	for _, v := range list {
-		c := Choice{Weight: uint(v), Item: v}
+		c := NewChoice(v, uint(v))
 		choices = append(choices, c)
 	}
 	t.Log("FYI mocked choices of", choices)


### PR DESCRIPTION
This is not in itself a huge convenience currently, however based on a toy implementation utilizing the latest go2 generics draft, it will end up being more ergonomic to use a constructor in this fashion where the type of `T` can be inferred rather than having to specify the type via a
`Choice(type T)` literal.