### PR TITLE
perf: manually inline SortSearchWrapper usage

### DIFF
--- a/examples/compbench/bench_test.go
+++ b/examples/compbench/bench_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 const BMMinChoices = 10
-const BMMaxChoices = 1000000
+const BMMaxChoices = 10_000_000
 
 func BenchmarkMultiple(b *testing.B) {
 	b.Run("jmc_randutil", func(b *testing.B) {

--- a/examples/compbench/bench_test.go
+++ b/examples/compbench/bench_test.go
@@ -1,0 +1,114 @@
+// Package compbench is used to generate informal comparative benchmarks vs
+// randutil.
+package compbench
+
+import (
+	"math/rand"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/jmcvetta/randutil"
+	"github.com/mroth/weightedrand"
+)
+
+const BMMinChoices = 10
+const BMMaxChoices = 1000000
+
+func BenchmarkMultiple(b *testing.B) {
+	b.Run("jmc_randutil", func(b *testing.B) {
+		for n := BMMinChoices; n <= BMMaxChoices; n *= 10 {
+			b.Run(strconv.Itoa(n), func(b *testing.B) {
+				choices := convertChoices(b, mockChoices(b, n))
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					randutil.WeightedChoice(choices)
+				}
+			})
+		}
+	})
+
+	b.Run("weightedrand", func(b *testing.B) {
+		for n := BMMinChoices; n <= BMMaxChoices; n *= 10 {
+			b.Run(strconv.Itoa(n), func(b *testing.B) {
+				choices := mockChoices(b, n)
+				chs := weightedrand.NewChooser(choices...)
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					chs.Pick()
+				}
+			})
+		}
+	})
+
+	b.Run("wr-parallel", func(b *testing.B) {
+		for n := BMMinChoices; n <= BMMaxChoices; n *= 10 {
+			b.Run(strconv.Itoa(n), func(b *testing.B) {
+				choices := mockChoices(b, n)
+				chs := weightedrand.NewChooser(choices...)
+				b.ResetTimer()
+				b.RunParallel(func(pb *testing.PB) {
+					rs := rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
+					for pb.Next() {
+						chs.PickSource(rs)
+					}
+				})
+			})
+		}
+	})
+}
+
+// The single usage case is an anti-pattern for the intended usage of this
+// library. Might as well keep some optional benchmarks for that to illustrate
+// the point.
+func BenchmarkSingle(b *testing.B) {
+	if testing.Short() {
+		b.Skip()
+	}
+
+	b.Run("jmc_randutil", func(b *testing.B) {
+		for n := BMMinChoices; n <= BMMaxChoices; n *= 10 {
+			b.Run(strconv.Itoa(n), func(b *testing.B) {
+				choices := convertChoices(b, mockChoices(b, n))
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					randutil.WeightedChoice(choices)
+				}
+			})
+		}
+	})
+
+	b.Run("weightedrand", func(b *testing.B) {
+		for n := BMMinChoices; n <= BMMaxChoices; n *= 10 {
+			b.Run(strconv.Itoa(n), func(b *testing.B) {
+				choices := mockChoices(b, n)
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					chs := weightedrand.NewChooser(choices...)
+					chs.Pick()
+				}
+			})
+		}
+	})
+}
+
+func mockChoices(tb testing.TB, n int) []weightedrand.Choice {
+	tb.Helper()
+	choices := make([]weightedrand.Choice, 0, n)
+	for i := 0; i < n; i++ {
+		s := '🥑'
+		w := rand.Intn(10)
+		c := weightedrand.NewChoice(s, uint(w))
+		choices = append(choices, c)
+	}
+	return choices
+}
+
+func convertChoices(tb testing.TB, cs []weightedrand.Choice) []randutil.Choice {
+	tb.Helper()
+	res := make([]randutil.Choice, len(cs))
+	for i, c := range cs {
+		res[i] = randutil.Choice{Weight: int(c.Weight), Item: c.Item}
+	}
+	return res
+}

--- a/examples/compbench/go.mod
+++ b/examples/compbench/go.mod
@@ -1,0 +1,10 @@
+module github.com/mroth/weightedrand/examples/compbench
+
+go 1.15
+
+require (
+	github.com/jmcvetta/randutil v0.0.0-20150817122601-2bb1b664bcff
+	github.com/mroth/weightedrand v0.0.0
+)
+
+replace github.com/mroth/weightedrand => ../..

--- a/examples/compbench/go.sum
+++ b/examples/compbench/go.sum
@@ -1,0 +1,2 @@
+github.com/jmcvetta/randutil v0.0.0-20150817122601-2bb1b664bcff h1:6NvhExg4omUC9NfA+l4Oq3ibNNeJUdiAF3iBVB0PlDk=
+github.com/jmcvetta/randutil v0.0.0-20150817122601-2bb1b664bcff/go.mod h1:ddfPX8Z28YMjiqoaJhNBzWHapTHXejnB5cDCUWDwriw=

--- a/weightedrand.go
+++ b/weightedrand.go
@@ -82,6 +82,8 @@ func (chs Chooser) PickSource(rs *rand.Rand) interface{} {
 // Thus, this is essentially manually inlined version.  In our use case here, it
 // results in a up to ~33% overall throughput increase for Pick().
 func searchInts(a []int, x int) int {
+	// Possible further future optimization for searchInts via SIMD if we want
+	// to write some Go assembly code: http://0x80.pl/articles/simd-search.html
 	i, j := 0, len(a)
 	for i < j {
 		h := int(uint(i+j) >> 1) // avoid overflow when computing h

--- a/weightedrand_test.go
+++ b/weightedrand_test.go
@@ -127,11 +127,11 @@ func verifyFrequencyCounts(t *testing.T, counts map[int]int, choices []Choice) {
 *	Benchmarks
 *******************************************************************************/
 
-const BMminChoices = 10
-const BMmaxChoices = 1000000
+const BMMinChoices = 10
+const BMMaxChoices = 1000000
 
 func BenchmarkNewChooser(b *testing.B) {
-	for n := BMminChoices; n <= BMmaxChoices; n *= 10 {
+	for n := BMMinChoices; n <= BMMaxChoices; n *= 10 {
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			choices := mockChoices(n)
 			b.ResetTimer()
@@ -144,7 +144,7 @@ func BenchmarkNewChooser(b *testing.B) {
 }
 
 func BenchmarkPick(b *testing.B) {
-	for n := BMminChoices; n <= BMmaxChoices; n *= 10 {
+	for n := BMMinChoices; n <= BMMaxChoices; n *= 10 {
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			choices := mockChoices(n)
 			chooser := NewChooser(choices...)
@@ -158,7 +158,7 @@ func BenchmarkPick(b *testing.B) {
 }
 
 func BenchmarkPickParallel(b *testing.B) {
-	for n := BMminChoices; n <= BMmaxChoices; n *= 10 {
+	for n := BMMinChoices; n <= BMMaxChoices; n *= 10 {
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			choices := mockChoices(n)
 			chooser := NewChooser(choices...)
@@ -176,34 +176,10 @@ func BenchmarkPickParallel(b *testing.B) {
 func mockChoices(n int) []Choice {
 	choices := make([]Choice, 0, n)
 	for i := 0; i < n; i++ {
-		s := "⚽️"
+		s := '🥑'
 		w := rand.Intn(10)
 		c := NewChoice(s, uint(w))
 		choices = append(choices, c)
 	}
 	return choices
 }
-
-// This following is a historic artifact from comparative benchmarking with
-// randutil, however it is not critical to ongoing development.
-
-// func BenchmarkRandutil(b *testing.B) {
-// 	if testing.Short() {
-// 		b.Skip()
-// 	}
-// 	for n := BMminChoices; n <= BMmaxChoices; n *= 10 {
-// 		b.Run(strconv.Itoa(n), func(b *testing.B) {
-// 			b.StopTimer()
-// 			choices := mockChoices(n)
-// 			choicesR := make([]randutil.Choice, len(choices), len(choices))
-// 			for i, c := range choices {
-// 				choicesR[i] = randutil.Choice{Weight: c.Weight, Item: c.Item}
-// 			}
-// 			b.StartTimer()
-
-// 			for i := 0; i < b.N; i++ {
-// 				randutil.WeightedChoice(choicesR)
-// 			}
-// 		})
-// 	}
-// }


### PR DESCRIPTION
The standard library `sort.SearchInts()` is just a convenience wrapper for the generic `sort.Search()` function, which takes a function closure to determine truthfulness. However, since this function is utilized within a for loop, it cannot currently be properly inlined by the compiler, resulting in non-trivial performance overhead.

Thus, this commit introduces what is essentially a manually inlined version. In our use case here, it results in a up to ~33% overall throughput increase for `Pick()`.

```
$ benchstat before.txt after.txt
name             old time/op  new time/op  delta
Pick/10-16       44.6ns ± 7%  35.3ns ± 5%  -20.88%  (p=0.000 n=10+10)
Pick/100-16      66.6ns ± 1%  50.0ns ± 1%  -24.88%  (p=0.000 n=10+9)
Pick/1000-16     95.8ns ± 1%  64.4ns ± 1%  -32.70%  (p=0.000 n=10+10)
Pick/10000-16     122ns ± 0%    82ns ± 0%  -32.77%  (p=0.000 n=10+10)
Pick/100000-16    160ns ± 1%   105ns ± 0%  -34.50%  (p=0.000 n=10+8)
Pick/1000000-16   298ns ± 1%   219ns ± 2%  -26.50%  (p=0.000 n=10+10)
```