### PR TITLE
checked constructor for potential error conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ import (
 func main() {
     rand.Seed(time.Now().UTC().UnixNano()) // always seed random!
 
-    c := wr.NewChooser(
+    chooser, _ := wr.NewChooser(
         wr.Choice{Item: "🍒", Weight: 0},
         wr.Choice{Item: "🍋", Weight: 1},
         wr.Choice{Item: "🍊", Weight: 1},
@@ -33,7 +33,7 @@ func main() {
     probability, and 🥑 with 0.5 probability. 🍒 will never be printed. (Note
     the weights don't have to add up to 10, that was just done here to make the
     example easier to read.) */
-    result := c.Pick().(string)
+    result := chooser.Pick().(string)
     fmt.Println(result)
 }
 ```

--- a/examples/compbench/bench_test.go
+++ b/examples/compbench/bench_test.go
@@ -32,7 +32,10 @@ func BenchmarkMultiple(b *testing.B) {
 		for n := BMMinChoices; n <= BMMaxChoices; n *= 10 {
 			b.Run(strconv.Itoa(n), func(b *testing.B) {
 				choices := mockChoices(b, n)
-				chs := weightedrand.NewChooser(choices...)
+				chs, err := weightedrand.NewChooser(choices...)
+				if err != nil {
+					b.Fatal(err)
+				}
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
 					chs.Pick()
@@ -45,7 +48,10 @@ func BenchmarkMultiple(b *testing.B) {
 		for n := BMMinChoices; n <= BMMaxChoices; n *= 10 {
 			b.Run(strconv.Itoa(n), func(b *testing.B) {
 				choices := mockChoices(b, n)
-				chs := weightedrand.NewChooser(choices...)
+				chs, err := weightedrand.NewChooser(choices...)
+				if err != nil {
+					b.Fatal(err)
+				}
 				b.ResetTimer()
 				b.RunParallel(func(pb *testing.PB) {
 					rs := rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
@@ -84,7 +90,7 @@ func BenchmarkSingle(b *testing.B) {
 				choices := mockChoices(b, n)
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					chs := weightedrand.NewChooser(choices...)
+					chs, _ := weightedrand.NewChooser(choices...)
 					chs.Pick()
 				}
 			})

--- a/examples/frequency/main.go
+++ b/examples/frequency/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"math/rand"
 	"time"
 
@@ -11,13 +12,16 @@ import (
 func main() {
 	rand.Seed(time.Now().UTC().UnixNano()) // always seed random!
 
-	c := wr.NewChooser(
+	c, err := wr.NewChooser(
 		wr.Choice{Item: '🍒', Weight: 0}, // alternatively: wr.NewChoice('🍒', 0)
 		wr.Choice{Item: '🍋', Weight: 1},
 		wr.Choice{Item: '🍊', Weight: 1},
 		wr.Choice{Item: '🍉', Weight: 3},
 		wr.Choice{Item: '🥑', Weight: 5},
 	)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	/* Let's pick a bunch of fruits so we can see the distribution in action! */
 	fruits := make([]rune, 40*18)

--- a/weightedrand.go
+++ b/weightedrand.go
@@ -35,15 +35,15 @@ type Chooser struct {
 	max    int
 }
 
-// NewChooser initializes a new Chooser for picking from the provided Choices.
-func NewChooser(cs ...Choice) (*Chooser, error) {
-	sort.Slice(cs, func(i, j int) bool {
-		return cs[i].Weight < cs[j].Weight
+// NewChooser initializes a new Chooser for picking from the provided choices.
+func NewChooser(choices ...Choice) (*Chooser, error) {
+	sort.Slice(choices, func(i, j int) bool {
+		return choices[i].Weight < choices[j].Weight
 	})
 
-	totals := make([]int, len(cs))
+	totals := make([]int, len(choices))
 	runningTotal := 0
-	for i, c := range cs {
+	for i, c := range choices {
 		weight := int(c.Weight)
 		if (maxInt - runningTotal) <= weight {
 			return nil, errWeightOverflow
@@ -56,7 +56,7 @@ func NewChooser(cs ...Choice) (*Chooser, error) {
 		return nil, errNoValidChoices
 	}
 
-	return &Chooser{data: cs, totals: totals, max: runningTotal}, nil
+	return &Chooser{data: choices, totals: totals, max: runningTotal}, nil
 }
 
 const (
@@ -79,12 +79,11 @@ var (
 
 // Pick returns a single weighted random Choice.Item from the Chooser.
 //
-// Utilizes global rand as the source of randomness -- you will likely want to
-// seed it.
-func (chs Chooser) Pick() interface{} {
-	r := rand.Intn(chs.max) + 1
-	i := searchInts(chs.totals, r)
-	return chs.data[i].Item
+// Utilizes global rand as the source of randomness.
+func (c Chooser) Pick() interface{} {
+	r := rand.Intn(c.max) + 1
+	i := searchInts(c.totals, r)
+	return c.data[i].Item
 }
 
 // PickSource returns a single weighted random Choice.Item from the Chooser,
@@ -96,10 +95,10 @@ func (chs Chooser) Pick() interface{} {
 //
 // It is the responsibility of the caller to ensure the provided rand.Source is
 // free from thread safety issues.
-func (chs Chooser) PickSource(rs *rand.Rand) interface{} {
-	r := rs.Intn(chs.max) + 1
-	i := searchInts(chs.totals, r)
-	return chs.data[i].Item
+func (c Chooser) PickSource(rs *rand.Rand) interface{} {
+	r := rs.Intn(c.max) + 1
+	i := searchInts(c.totals, r)
+	return c.data[i].Item
 }
 
 // The standard library sort.SearchInts() just wraps the generic sort.Search()

--- a/weightedrand.go
+++ b/weightedrand.go
@@ -46,14 +46,14 @@ func NewChooser(cs ...Choice) (*Chooser, error) {
 	for i, c := range cs {
 		weight := int(c.Weight)
 		if (maxInt - runningTotal) <= weight {
-			return nil, ErrWeightOverflow
+			return nil, errWeightOverflow
 		}
 		runningTotal += weight
 		totals[i] = runningTotal
 	}
 
 	if runningTotal <= 1 {
-		return nil, ErrNoValidChoices
+		return nil, errNoValidChoices
 	}
 
 	return &Chooser{data: cs, totals: totals, max: runningTotal}, nil
@@ -71,10 +71,10 @@ var (
 	// for the current platform (e.g. math.MaxInt32 or math.MaxInt64), then
 	// the internal running total will overflow, resulting in an imbalanced
 	// distribution generating improper results.
-	ErrWeightOverflow = errors.New("sum of Choice Weights exceeds max int")
+	errWeightOverflow = errors.New("sum of Choice Weights exceeds max int")
 	// If there are no Choices available to the Chooser with a weight >= 1,
 	// there are no valid choices and Pick would produce a runtime panic.
-	ErrNoValidChoices = errors.New("zero Choices with Weight >= 1")
+	errNoValidChoices = errors.New("zero Choices with Weight >= 1")
 )
 
 // Pick returns a single weighted random Choice.Item from the Chooser.

--- a/weightedrand.go
+++ b/weightedrand.go
@@ -36,18 +36,7 @@ type Chooser struct {
 }
 
 // NewChooser initializes a new Chooser for picking from the provided Choices.
-func NewChooser(cs ...Choice) Chooser {
-	res, err := NewChooserChecked(cs...)
-	if err != nil {
-		panic(err)
-	}
-	return *res
-}
-
-// NewChooserChecked initializes a new Chooser for picking from the provided
-// Choices, but will explicitly error in situations where an unsafe Chooser
-// might be produced.
-func NewChooserChecked(cs ...Choice) (*Chooser, error) {
+func NewChooser(cs ...Choice) (*Chooser, error) {
 	sort.Slice(cs, func(i, j int) bool {
 		return cs[i].Weight < cs[j].Weight
 	})
@@ -75,8 +64,8 @@ const (
 	maxInt  = 1<<(intSize-1) - 1
 )
 
-// Possible errors returned by NewChooserChecked, preventing the creation of
-// a Chooser with unsafe runtime states.
+// Possible errors returned by NewChooser, preventing the creation of a Chooser
+// with unsafe runtime states.
 var (
 	// If the sum of provided Choice weights exceed the maximum integer value
 	// for the current platform (e.g. math.MaxInt32 or math.MaxInt64), then

--- a/weightedrand_test.go
+++ b/weightedrand_test.go
@@ -18,7 +18,7 @@ import (
 // not on any absolute scoring system. In this trivial case, we will assign a
 // weight of 0 to all but one fruit, so that the output will be predictable.
 func Example() {
-	chooser := NewChooser(
+	chooser, _ := NewChooser(
 		NewChoice('🍋', 0),
 		NewChoice('🍊', 0),
 		NewChoice('🍉', 0),
@@ -42,7 +42,7 @@ const (
 	testIterations = 1000000
 )
 
-func TestNewChooserChecked(t *testing.T) {
+func TestNewChooser(t *testing.T) {
 	tests := []struct {
 		name    string
 		cs      []Choice
@@ -71,9 +71,9 @@ func TestNewChooserChecked(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := NewChooserChecked(tt.cs...)
+			_, err := NewChooser(tt.cs...)
 			if err != tt.wantErr {
-				t.Errorf("NewChooserChecked() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("NewChooser() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
@@ -84,7 +84,10 @@ func TestNewChooserChecked(t *testing.T) {
 // often than choices with a lower weight.
 func TestChooser_Pick(t *testing.T) {
 	choices := mockFrequencyChoices(t, testChoices)
-	chooser := NewChooser(choices...)
+	chooser, err := NewChooser(choices...)
+	if err != nil {
+		t.Fatal(err)
+	}
 	t.Log("totals in chooser", chooser.totals)
 
 	// run Pick() a million times, and record how often it returns each of the
@@ -104,7 +107,10 @@ func TestChooser_Pick(t *testing.T) {
 // randomness.
 func TestChooser_PickSource(t *testing.T) {
 	choices := mockFrequencyChoices(t, testChoices)
-	chooser := NewChooser(choices...)
+	chooser, err := NewChooser(choices...)
+	if err != nil {
+		t.Fatal(err)
+	}
 	t.Log("totals in chooser", chooser.totals)
 
 	counts1 := make(map[int]int)
@@ -174,7 +180,7 @@ func BenchmarkNewChooser(b *testing.B) {
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
-				_ = NewChooser(choices...)
+				_, _ = NewChooser(choices...)
 			}
 		})
 	}
@@ -184,7 +190,10 @@ func BenchmarkPick(b *testing.B) {
 	for n := BMMinChoices; n <= BMMaxChoices; n *= 10 {
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			choices := mockChoices(n)
-			chooser := NewChooser(choices...)
+			chooser, err := NewChooser(choices...)
+			if err != nil {
+				b.Fatal(err)
+			}
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
@@ -198,7 +207,10 @@ func BenchmarkPickParallel(b *testing.B) {
 	for n := BMMinChoices; n <= BMMaxChoices; n *= 10 {
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			choices := mockChoices(n)
-			chooser := NewChooser(choices...)
+			chooser, err := NewChooser(choices...)
+			if err != nil {
+				b.Fatal(err)
+			}
 			b.ResetTimer()
 			b.RunParallel(func(pb *testing.PB) {
 				rs := rand.New(rand.NewSource(time.Now().UTC().UnixNano()))

--- a/weightedrand_test.go
+++ b/weightedrand_test.go
@@ -51,17 +51,17 @@ func TestNewChooser(t *testing.T) {
 		{
 			name:    "zero choices",
 			cs:      []Choice{},
-			wantErr: ErrNoValidChoices,
+			wantErr: errNoValidChoices,
 		},
 		{
 			name:    "no choices with positive weight",
 			cs:      []Choice{{Item: 'a', Weight: 0}, {Item: 'b', Weight: 0}},
-			wantErr: ErrNoValidChoices,
+			wantErr: errNoValidChoices,
 		},
 		{
 			name:    "weight overflow",
 			cs:      []Choice{{Item: 'a', Weight: maxInt/2 + 1}, {Item: 'b', Weight: maxInt/2 + 1}},
-			wantErr: ErrWeightOverflow,
+			wantErr: errWeightOverflow,
 		},
 		{
 			name:    "nominal case",

--- a/weightedrand_test.go
+++ b/weightedrand_test.go
@@ -42,6 +42,43 @@ const (
 	testIterations = 1000000
 )
 
+func TestNewChooserChecked(t *testing.T) {
+	tests := []struct {
+		name    string
+		cs      []Choice
+		wantErr error
+	}{
+		{
+			name:    "zero choices",
+			cs:      []Choice{},
+			wantErr: ErrNoValidChoices,
+		},
+		{
+			name:    "no choices with positive weight",
+			cs:      []Choice{{Item: 'a', Weight: 0}, {Item: 'b', Weight: 0}},
+			wantErr: ErrNoValidChoices,
+		},
+		{
+			name:    "weight overflow",
+			cs:      []Choice{{Item: 'a', Weight: maxInt/2 + 1}, {Item: 'b', Weight: maxInt/2 + 1}},
+			wantErr: ErrWeightOverflow,
+		},
+		{
+			name:    "nominal case",
+			cs:      []Choice{{Item: 'a', Weight: 1}, {Item: 'b', Weight: 2}},
+			wantErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewChooserChecked(tt.cs...)
+			if err != tt.wantErr {
+				t.Errorf("NewChooserChecked() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 // TestChooser_Pick assembles a list of Choices, weighted 0-9, and tests that
 // over the course of 1,000,000 calls to Pick() each choice is returned more
 // often than choices with a lower weight.


### PR DESCRIPTION
This commit introduces a variant of the `NewChooser` constructor that will pre-check for and error on conditions that could later cause a runtime issue during `Pick`.

The conditions handled are a lack of valid choices (fairly preventable by consumers) and a potential integer overflow in the running total (far more subtle, but an edge case). In general, it is highly preferable for us to expose these predictable scenarios rather than potentially allowing a runtime error that could panic or produce invalid results. I was thinking of this [Cloudflare blog post](https://blog.cloudflare.com/how-and-why-the-leap-second-affected-cloudflare-dns/) as a similar scenario when proposing these changes.

The initial version of this is API backwards compatible by introducing a new `NewChooserChecked` function and changing the behavior of the `NewChooser` to `panic` at construction time in invalid states. However I'd like to iterate towards a more simple API before making this change. Some options:

1. Expose both `NewChooser` and `NewChooserChecked` (as in the current proof of concept commit). I am not generally in favor of this as it introduces more user-complexity than needed and the distinction here is not significantly subtle to require the cognitive overhead of both options.

2. Privatize `newChooserChecked` and keep the panic on error behavior on `NewChooser`. Pros: API backwards compatibility (though pre-release, so not as important), simpler caller semantics, the error conditions are currently fairly edge and unlikely to be encountered in typical usage. Cons: doesn't force error handling, and the overflow error scenario in particular, being an edge case, is unlikely to be pre-checked by consumers of the API, and panic recovery is a pain.

3. Make `NewChooserChecked` the new `NewChooser` (renaming/replacing it), which introduces an API change in the return value of the constructor to `(*Chooser, error)`. This would require a semantic version bump, but we're still in pre-release versioning so it makes sense to iterate towards the most ideal API now while we have the flexibility. Pros: Forces dealing with the potential error condition. Cons: Forces slightly more complex initialization code everywhere (e.g. checking err), current error conditions are not incredibly likely to emerge in typical usage.

Currently my current leaning is towards **option number 3** (especially since the potentially use cases of this library include problem domains with highly reliable characteristics are desirable, such as load-balancing) but I would love to hear from actual users of this library. (To best have an informed opinion, I suggest reviewing the actual source code changes so you can see how likely you are to encounter the potential error conditions in your own usage.)

Some additional API considerations:
- If going with option 1 or 3, whether to additionally export the sentinel error types (e.g. `ErrWeightOverflow`) or not (currently exported in initial commit). _My initial inclination is that exporting them complicates the external surface of the API with minimal benefit, and I cannot currently conceive of a situation where a caller fo the constructor would act upon different error conditions significantly differently._ (please let me know if you can think of a need here!).
- There are some additional minor unrelated API changes I will want to consider making for ergonomics, so if this ends up going that route, I'll open additional issues to discuss those and they can potentially be rolled into a single breaking version bump.